### PR TITLE
feat: recursive env file search through parent dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.2.0 (2022-10-12)
+
+- Recursively search up through parent directories for `.env` files when a local copy cannot be found
+
 ## v0.1.0 (2022-07-26)
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Source your environment variables from `.env` when running CLI commands.
 [![Version](https://img.shields.io/github/v/tag/justintime50/clienv)](https://github.com/justintime50/clienv/releases)
 [![Licence](https://img.shields.io/github/license/justintime50/clienv)](LICENSE)
 
-Sometimes you may want to source environment variables from a file (eg: `.env`) that is local to a specific project - variables that may not exist in your shell config or you only want them on a single command run. Enter `clienv`, the CLI environment tool that sources your env vars locally.
+Sometimes you may want to source environment variables from a file (eg: `.env`) that is local to a specific project or somewhere in a parent directory - variables that may not exist in your shell config or you only want them on a single command run. Enter `clienv`, the CLI environment tool that sources your env vars found in env files.
 
 ## Install
 
@@ -20,8 +20,8 @@ brew install clienv
 
 ## Usage
 
-1. Place a `.env` file in the root of your project or wherever you are going to call your commands from
-2. Run `clienv` prior to any of your commands and the tool will source your `.env` variables for that command run. You can chain multiple commands together too.
+1. Place a `.env` file in the root of your project or in a parent directory on the same path
+2. Run `clienv` prior to any of your commands and the tool will source your `.env` variables for that command run. You can also chain multiple commands together.
 
 ```bash
 clienv my_command

--- a/src/clienv.sh
+++ b/src/clienv.sh
@@ -5,13 +5,25 @@
 # Source your environment variables when running commands from the CLI
 # Usage: clienv make test
 
-# Set all vars sourced here as exported
+# Export all env vars found for use by CLI commands
 set -a
 
 # Source environment variables
 ENVFILES=".env" # Separate entries with spaces
 for envfile in "$ENVFILES"; do
-    [ -f "$envfile" ] && . "$envfile"
+    while true; do
+        if [ -f "$envfile" ]; then
+            . "$envfile"
+            break
+        else
+            if [ "$(pwd)" == "/" ]; then
+                # If we arrive at the root of the filesystem, stop searching for env files
+                break
+            else
+                cd .. || exit 1
+            fi
+        fi
+    done
 done
 
 # Execute the remaining commands


### PR DESCRIPTION
Recursively search up through parent directories for `.env` files when a local copy cannot be found
